### PR TITLE
fix message API, the field inside data should reflect the call URL

### DIFF
--- a/app/src/androidTest/java/nl/eduvpn/app/service/SerializerServiceTest.java
+++ b/app/src/androidTest/java/nl/eduvpn/app/service/SerializerServiceTest.java
@@ -112,8 +112,8 @@ public class SerializerServiceTest {
         Maintenance maintenance = new Maintenance(utcCalendar.getTime(), utcCalendar.getTime(), utcCalendar.getTime());
         Notification notification = new Notification(utcCalendar.getTime(), "Example notification");
         List<Message> messageList = Arrays.asList(maintenance, notification);
-        JSONObject serializedList = _serializerService.serializeMessageList(messageList);
-        List<Message> deserializedList = _serializerService.deserializeMessageList(serializedList);
+        JSONObject serializedList = _serializerService.serializeMessageList(messageList, "system_messages");
+        List<Message> deserializedList = _serializerService.deserializeMessageList(serializedList, "system_messages");
         assertEquals(messageList.size(), deserializedList.size());
         assertEquals(_norm(messageList.get(0).getDate()), _norm(deserializedList.get(0).getDate()));
         assertEquals(_norm(((Maintenance)messageList.get(0)).getStart()), _norm(((Maintenance)deserializedList.get(0)).getStart()));

--- a/app/src/main/java/nl/eduvpn/app/fragment/ConnectionStatusFragment.java
+++ b/app/src/main/java/nl/eduvpn/app/fragment/ConnectionStatusFragment.java
@@ -140,7 +140,7 @@ public class ConnectionStatusFragment extends Fragment implements VPNService.Con
             @Override
             public void onSuccess(JSONObject result) {
                 try {
-                    List<Message> systemMessagesList = _serializerService.deserializeMessageList(result);
+                    List<Message> systemMessagesList = _serializerService.deserializeMessageList(result, "system_messages");
                     messagesAdapter.setSystemMessages(systemMessagesList);
                 } catch (SerializerService.UnknownFormatException ex) {
                     ErrorDialog.show(getContext(), R.string.error_dialog_title, ex.toString());
@@ -158,7 +158,7 @@ public class ConnectionStatusFragment extends Fragment implements VPNService.Con
             @Override
             public void onSuccess(JSONObject result) {
                 try {
-                    List<Message> userMessagesList = _serializerService.deserializeMessageList(result);
+                    List<Message> userMessagesList = _serializerService.deserializeMessageList(result, "user_messages");
                     messagesAdapter.setUserMessages(userMessagesList);
                 } catch (SerializerService.UnknownFormatException ex) {
                     ErrorDialog.show(getContext(), R.string.error_dialog_title, ex.toString());

--- a/app/src/main/java/nl/eduvpn/app/service/SerializerService.java
+++ b/app/src/main/java/nl/eduvpn/app/service/SerializerService.java
@@ -280,13 +280,14 @@ public class SerializerService {
      * Deserializes a JSON with a list of messages into an ArrayList of message object.
      *
      * @param jsonObject The JSON to deserialize.
+     * @param String the message source, either "user_messages" or "system_messages"
      * @return The message instances in a list.
      * @throws UnknownFormatException Thrown if there was a problem while parsing.
      */
-    public List<Message> deserializeMessageList(JSONObject jsonObject) throws UnknownFormatException {
+    public List<Message> deserializeMessageList(JSONObject jsonObject, String messageSource) throws UnknownFormatException {
         try {
             JSONObject dataObject = jsonObject.getJSONObject("data");
-            JSONArray messagesArray = dataObject.getJSONArray("messages");
+            JSONArray messagesArray = dataObject.getJSONArray(messageSource);
             List<Message> result = new ArrayList<>();
             for (int i = 0; i < messagesArray.length(); ++i) {
                 JSONObject messageObject = messagesArray.getJSONObject(i);
@@ -316,16 +317,17 @@ public class SerializerService {
      * Serializes a list of messages into a JSON format.
      *
      * @param messageList The list of messages to serialize.
+     * @param String the message source, either "user_messages" or "system_messages"
      * @return The messages as a JSON object.
      * @throws UnknownFormatException Thrown if there was an error constructing the JSON.
      */
-    public JSONObject serializeMessageList(List<Message> messageList) throws UnknownFormatException {
+    public JSONObject serializeMessageList(List<Message> messageList, String messageSource) throws UnknownFormatException {
         try {
             JSONObject result = new JSONObject();
             JSONObject dataObject = new JSONObject();
             result.put("data", dataObject);
             JSONArray messagesArray = new JSONArray();
-            dataObject.put("messages", messagesArray);
+            dataObject.put(messageSource, messagesArray);
             for (Message message : messageList) {
                 JSONObject messageObject = new JSONObject();
                 messageObject.put("date", API_DATE_FORMAT.format(message.getDate()));


### PR DESCRIPTION
in the previous API.md the field for reading the messages was "messages" for both "user_messages" and "system_messages". This fixes that and uses "user_messages" and "system_messages" in those cases to be more in line with the other API responses.