### PR TITLE
do not show 2FA profiles

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.2.4 (...)
+- drop 2FA support in Android app until new server release in Q1 where 2FA 
+  moves to the browser
+
 ## 1.2.3 (2018-06-28)
 - fix Gradle build (#165)
 - immediately show "add provider" page when starting the app and no

--- a/app/src/main/java/nl/eduvpn/app/fragment/HomeFragment.java
+++ b/app/src/main/java/nl/eduvpn/app/fragment/HomeFragment.java
@@ -384,6 +384,11 @@ public class HomeFragment extends Fragment {
                     List<Profile> profiles = _serializerService.deserializeProfileList(result);
                     List<Pair<Instance, Profile>> newItems = new ArrayList<>();
                     for (Profile profile : profiles) {
+                        // we do not want to provide access to 2FA profiles
+                        // on Android, so do not show them at all...
+                        if (profile.getTwoFactor()) {
+                            continue;
+                        }
                         newItems.add(new Pair<>(instance, profile));
                     }
                     adapter.addItemsIfNotAdded(newItems);


### PR DESCRIPTION
until eduVPN 2.0 server release we do not want to support 2FA profiles on Android.