### PR TITLE
show gradle warnings

### DIFF
--- a/build_app.sh
+++ b/build_app.sh
@@ -43,7 +43,7 @@ SIGNED_APK=${PROJECT_DIR}/eduVPN-${GIT_TAG}.apk
 (
     export ANDROID_HOME=${SDK_DIR}
     cd "${APP_DIR}" || exit
-    ./gradlew ${GRADLE_TASK} --stacktrace || exit
+    ./gradlew ${GRADLE_TASK} --warning-mode all --stacktrace || exit
 )
 
 ###############################################################################


### PR DESCRIPTION
> Deprecated Gradle features were used in this build, making it incompatible with Gradle 6.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/5.6.4/userguide/command_line_interface.html#sec:command_line_warnings
