### PR TITLE
Replace Google SDK usage with Android-Rebuilds 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "ics-openvpn"]
 	path = ics-openvpn
-	url = https://github.com/eduvpn/ics-openvpn
+	url = https://github.com/jja2000/ics-openvpn
 [submodule "appauth"]
 	path = appauth
 	url = https://github.com/eduvpn/AppAuth-Android.git

--- a/README.md
+++ b/README.md
@@ -54,13 +54,15 @@ not tested, but 1GB definitely does not work.
         swig \
         java-1.8.0-openjdk \
         java-1.8.0-openjdk-devel \
-        ncurses-compat-libs
+        ncurses-compat-libs \
+        ninja-build \
+        cmake
 
 We last tested this (successfully) on 2021-03-18 with Fedora 33.
 
 ### Debian
 
-    $ sudo apt -y install openjdk-8-jdk git curl unzip swig ninja-build
+    $ sudo apt -y install openjdk-8-jdk git curl unzip swig ninja-build cmake
 
 ## Key Store
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ android {
         targetSdkVersion 29
         versionCode 17
         versionName "2.0.4"
-        ndkVersion "21.0.6113669"
+        ndkVersion "21.4.0"
 
         vectorDrawables.useSupportLibrary = true
 

--- a/builder_setup.sh
+++ b/builder_setup.sh
@@ -6,18 +6,20 @@
 
 SDK_DIR=${HOME}/android-sdk
 
-# current as of 20191028
-# see https://developer.android.com/studio/#downloads "Command line tools only"
-SDK_VERSION=6858069
+# Android-Rebuilds F-Droid Mirror, will have to be changed to something hosted by SURF or the original AR repo considering the NDK is already unavailable
+SDK_URL=https://mirror.f-droid.org/android-free/repository/
 
-# Always use latest from https://developer.android.com/studio/releases/build-tools
-BUILD_TOOLS_VERSION=29.0.3
+# Android-Rebuilds NDK mirror, temporary host because F-Droid does not host NDK version R21
+NDK_URL=https://aaio.eu/ndk/
+NDK_FILE=android-ndk-0-linux-x86_64.tar.bz2
 
-# see app/build.gradle for "targetSdkVersion"
-PLATFORM_VERSION=29
-
-# should not require modification...
-SDK_URL=https://dl.google.com/android/repository/commandlinetools-linux-${SDK_VERSION}_latest.zip
+declare -a arr=(
+    "sdk-repo-linux-tools-26.1.1.zip" # Includes sdkmanager
+    "sdk-repo-linux-platforms-eng.11.0.0_r27.zip" # To compile ics-openvpn
+    "sdk-repo-linux-platforms-eng.10.0.0_r36.zip" # To compile eduvpn
+    "sdk-repo-linux-platform-tools-eng.10.0.0_r14.zip" # Contains tools like adb and fastboot
+    "sdk-repo-linux-build-tools-eng.10.0.0_r14.zip" # Contains tools like apksigner
+)
 
 ###############################################################################
 # SETUP
@@ -25,24 +27,44 @@ SDK_URL=https://dl.google.com/android/repository/commandlinetools-linux-${SDK_VE
 
 # create and populate SDK directory
 (
-    mkdir -p "${SDK_DIR}"
+    mkdir -p "${SDK_DIR}" "${SDK_DIR}"/platforms "${SDK_DIR}"/build-tools "${SDK_DIR}"/ndk "${SDK_DIR}"/ndk/21.4.0
     cd "${SDK_DIR}" || exit
-    curl -L -O ${SDK_URL}
-    unzip -q commandlinetools-linux-${SDK_VERSION}_latest.zip
-    rm commandlinetools-linux-${SDK_VERSION}_latest.zip
-)
+    for i in "${arr[@]}"
+    do
+        echo "Downloading $i"
+        curl -L -O ${SDK_URL}/$i
 
-# accept licenses
-(
-    cd "${SDK_DIR}" || exit
-    yes | cmdline-tools/bin/sdkmanager --sdk_root=${SDK_DIR} --licenses
-)
+        echo "Unzipping $i"
+        unzip -q $i -d ${SDK_DIR}
+        rm $i
 
-# install required SDK components
-(
-    cd "${SDK_DIR}" || exit
-    cmdline-tools/bin/sdkmanager --sdk_root=${SDK_DIR} --update
-    cmdline-tools/bin/sdkmanager --sdk_root=${HOME}/android-sdk "ndk;21.0.6113669"
-    cmdline-tools/bin/sdkmanager --sdk_root=${HOME}/android-sdk "build-tools;${BUILD_TOOLS_VERSION}"
-    cmdline-tools/bin/sdkmanager --sdk_root=${HOME}/android-sdk "platforms;android-${PLATFORM_VERSION}"
+        # Some of these zips need to be either placed in subfolders or have to be
+        # renamed due to gradle warnings
+        if [ $i = sdk-repo-linux-tools-26.1.1.zip ]
+        then
+            mv tools/ cmdline-tools/
+        elif [ $i = sdk-repo-linux-build-tools-eng.10.0.0_r14.zip ]
+        then
+            mv android-10/ build-tools/29.0.2
+        elif [ $i = sdk-repo-linux-platforms-eng.10.0.0_r36.zip ]
+        then
+            mv android-10/ platforms/android-29
+        elif [ $i = sdk-repo-linux-platforms-eng.11.0.0_r27.zip ]
+        then
+            mv android-11/ platforms/android-30
+        fi
+
+        echo "Content of $i in place"
+        echo ""
+    done
+
+    echo "Downloading ${NDK_FILE}. This might take a while depending on your connection"
+    curl -L -O ${NDK_URL}/${NDK_FILE}
+    echo "Extracting ${NDK_FILE}. This might take a while depending on your system."
+    tar xjf ${NDK_FILE}
+    rm ${NDK_FILE}
+    mv android-ndk-r21e/* "${SDK_DIR}"/ndk/21.4.0/
+    rmdir android-ndk-r21e/
+    echo "Content of ${NDK_FILE} in place"
+    echo ""
 )


### PR DESCRIPTION
Using Google's SDK limits the usage of this app on "Incompatible" versions of Android like Sailfish OS, LineageOS and Anbox.
![image](https://user-images.githubusercontent.com/14004235/115297302-5892a200-a15c-11eb-9403-7a74777f9f55.png)

Luckily the SDK is mostly licensed under the Apache license and can be recompiled.
This means that usage of the app on "Incompatible" platforms can legally be done and the version number/download link can be static (unless you or upstream ics-openvpn/appauth want to update).

Some notes:
- This will depend on https://github.com/eduvpn/ics-openvpn/pull/13 getting merged
If that ends up getting merged I'll need to make the modules point to your repo again instead of mine.
- Fedora 33 will work to build the app, but because of the cmake version requirements in ics-openvpn some older distro's might not (by default)
While I don't think this will be a problem for us, we might need to advise to download a backported version (in case of an older debian version) or possibly include the download in the builder_setup script
- I have not tested the tests
They might rely on the system-images shipped with sdk-manager by default. I have not included these yet to save space.
- I am currently hosting the NDK zip myself
As I outlined in comment in builder_setup.sh, I am currently self-hosting the NDK zip I compiled. This is because Android-Rebuilds currently only ships NDK R20b at max while eduVPN needs 21 at minimum. I would advise compiling your own version or uploading the one I compiled to somewhere hosted by the project so I can point to it. I cannot guarantee this mirror will be up forever.
- I have not changed the "build from git" script
Building from the script when cloning the master branch will break after merging this MR because the ics-openvpn submodule will be outdated so gradle will try to redownload the wrong cmake version.

If you feel like anything is missing or not working, let me know.