### PR TITLE
Add Android-Rebuilds as a way to build the app

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,13 @@ Additional documentation
 
 ## Setup
 
+### Google SDK
     $ ./builder_setup.sh
+
+### Android Rebuilds SDK
+    $ ./ar_builder_setup.sh
+
+[Android Rebuilds](https://android-rebuilds.beuc.net) is a reproducibly built version of the Android SDK. This is possible because the entire SDK is licensed under the Open Source APACHE license. This allows you to compile apps without having to accept Google's license agreement within sdkmanager.
 
 ## Build
 
@@ -96,6 +102,10 @@ development release.
 
     $ ./build_app_git.sh
 
+If you have set up the Android Rebuilds SDK you can use
+
+    $ ./ar_build_app_git.sh
+
 You'll find the signed output APK in ${HOME}/Projects.
 
 ### Tar
@@ -105,5 +115,9 @@ including all submodules, use the following after modifying the file if
 necessary. Use this if you want to use an official release.
 
     $ ./build_app_tar.sh
+
+If you have set up the Android Rebuilds SDK you can use
+
+    $ ./ar_build_app_tar.sh
 
 You'll find the signed output APK in ${HOME}/Projects.

--- a/README.md
+++ b/README.md
@@ -54,13 +54,16 @@ not tested, but 1GB definitely does not work.
         swig \
         java-1.8.0-openjdk \
         java-1.8.0-openjdk-devel \
-        ncurses-compat-libs
+        ncurses-compat-libs \
+        ninja-build \
+        cmake \
+	    pv
 
-We last tested this (successfully) on 2021-03-18 with Fedora 33.
+We last tested this (successfully) on 2021-05-11 with Fedora 34.
 
 ### Debian
 
-    $ sudo apt -y install openjdk-8-jdk git curl unzip swig ninja-build
+    $ sudo apt -y install openjdk-8-jdk git curl unzip swig ninja-build cmake pv
 
 ## Key Store
 

--- a/ar_build_app_git.sh
+++ b/ar_build_app_git.sh
@@ -1,0 +1,75 @@
+#!/bin/sh
+
+###############################################################################
+# CONFIGURATION
+###############################################################################
+
+SDK_DIR=${HOME}/android-rebuilds-sdk
+KEY_STORE=${HOME}/android.jks
+
+GIT_REPO=https://github.com/eduvpn/android
+GIT_TAG=2.0.4
+#GIT_TAG=master
+
+PROJECT_DIR=${HOME}/Projects
+APP_DIR=${PROJECT_DIR}/eduvpn-android-$(date +%Y%m%d%H%M%S)
+
+# eduVPN
+GRADLE_TASK=app:assembleBasicRelease
+UNSIGNED_APK=${APP_DIR}/app/build/outputs/apk/basic/release/app-basic-release-unsigned.apk 
+SIGNED_APK=${PROJECT_DIR}/eduVPN-${GIT_TAG}.apk
+
+# Let's Connect!
+#GRADLE_TASK=app:assembleHomeRelease
+#UNSIGNED_APK=${APP_DIR}/app/build/outputs/apk/home/release/app-home-release-unsigned.apk 
+#SIGNED_APK=${PROJECT_DIR}/LetsConnect-${GIT_TAG}.apk
+
+###############################################################################
+# CLONE
+###############################################################################
+
+(
+    mkdir -p "${PROJECT_DIR}"
+
+    git clone --recursive -b ${GIT_TAG} ${GIT_REPO} "${APP_DIR}"
+)
+
+###############################################################################
+# PATCH
+###############################################################################
+
+(
+    SCRIPT_DIR=${PWD}
+    cd "${APP_DIR}" || exit
+    echo "Patching cloned repo"
+    # Checking beforehand if patch can be applied or not:
+    # Patching current repo
+    # Checking beforehand if patch can be applied or not:
+    # If reversing the patch (-R) works that means the patch was already applied, do a dry run to not apply anything (--check)
+    # This all means reversing the patch will fail succesfully™
+    # If the patch was already applied the second command will not execute (OR operator)
+    # If reversing the patch does not work it will actually patch the to be changed files
+    git apply ${SCRIPT_DIR}/patches/android-rebuilds/ar.patch
+    echo "Patched cloned repo"
+ )
+
+###############################################################################
+# BUILD
+###############################################################################
+
+(
+    export ANDROID_HOME=${SDK_DIR}
+    cd "${APP_DIR}" || exit
+    ./gradlew ${GRADLE_TASK} --warning-mode all --stacktrace || exit
+)
+
+###############################################################################
+# SIGN
+###############################################################################
+
+(
+    # pick the newest build tools in case multiple versions are available
+    BUILD_TOOLS_VERSION=$(ls ${SDK_DIR}/build-tools/ | sort -r | head -1)
+    ${SDK_DIR}/build-tools/${BUILD_TOOLS_VERSION}/apksigner sign --ks "${KEY_STORE}" "${UNSIGNED_APK}" || exit
+    cp "${UNSIGNED_APK}" "${SIGNED_APK}" || exit
+)

--- a/ar_build_app_tar.sh
+++ b/ar_build_app_tar.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+
+###############################################################################
+# CONFIGURATION
+###############################################################################
+
+SDK_DIR=${HOME}/android-rebuilds-sdk
+KEY_STORE=${HOME}/android.jks
+
+V=2.0.4
+DOWNLOAD_URL=https://github.com/eduvpn/android/releases/download/${V}/eduvpn-android-${V}.tar.xz
+
+PROJECT_DIR=${HOME}/Projects
+APP_DIR=${PROJECT_DIR}/eduvpn-android-${V}
+
+# eduVPN
+GRADLE_TASK=app:assembleBasicRelease
+UNSIGNED_APK=${APP_DIR}/app/build/outputs/apk/basic/release/app-basic-release-unsigned.apk 
+SIGNED_APK=${PROJECT_DIR}/eduVPN-${V}.apk
+
+# Let's Connect!
+#GRADLE_TASK=app:assembleHomeRelease
+#UNSIGNED_APK=${APP_DIR}/app/build/outputs/apk/home/release/app-home-release-unsigned.apk 
+#SIGNED_APK=${PROJECT_DIR}/LetsConnect-${V}.apk
+
+###############################################################################
+# CLONE
+###############################################################################
+
+(
+    mkdir -p "${PROJECT_DIR}"
+    cd "${PROJECT_DIR}" || exit
+
+    curl -L -o ${PROJECT_DIR}/eduvpn-android-${V}.tar.xz "${DOWNLOAD_URL}"
+    tar -xJf ${PROJECT_DIR}/eduvpn-android-${V}.tar.xz
+)
+
+###############################################################################
+# PATCH
+###############################################################################
+
+(
+    SCRIPT_DIR=${PWD}
+    cd "${APP_DIR}" || exit
+    echo "Patching extracted sources"
+    # Checking beforehand if patch can be applied or not:
+    # If reversing the patch (-R) works that means the patch was already applied, do a dry run to not apply anything (--dry-run) and do not output anything extra for it (-s)
+    # This all means reversing the patch will fail succesfully™ (hence -s will not silence _all_ errors)
+    # If the patch was already applied the second command will not execute (OR operator)
+    # If reversing the patch does not work it will actually patch the to be changed files
+    patch -p1 -s < ${SCRIPT_DIR}/patches/android-rebuilds/ar.patch
+    echo "Patched extracted sources"
+)
+
+###############################################################################
+# BUILD
+###############################################################################
+
+(
+    export ANDROID_HOME=${SDK_DIR}
+    cd "${APP_DIR}" || exit
+    ./gradlew ${GRADLE_TASK} --warning-mode all --stacktrace || exit
+)
+
+###############################################################################
+# SIGN
+###############################################################################
+
+(
+    # pick the newest build tools in case multiple versions are available
+    BUILD_TOOLS_VERSION=$(ls ${SDK_DIR}/build-tools/ | sort -r | head -1)
+    ${SDK_DIR}/build-tools/${BUILD_TOOLS_VERSION}/apksigner sign --ks "${KEY_STORE}" "${UNSIGNED_APK}" || exit
+    cp "${UNSIGNED_APK}" "${SIGNED_APK}" || exit
+)

--- a/ar_builder_setup.sh
+++ b/ar_builder_setup.sh
@@ -1,0 +1,68 @@
+###############################################################################
+# ANDROID-REBUILDS SDK CONFIGURATION
+###############################################################################
+
+AR_SDK_DIR=${HOME}/android-rebuilds-sdk
+
+# Android-Rebuilds F-Droid Mirror, will have to be changed to something hosted by SURF or the original AR repo considering the NDK is already unavailable
+AR_SDK_URL=https://mirror.f-droid.org/android-free/repository/
+
+# Android-Rebuilds NDK mirror, temporary host because F-Droid does not host NDK version R21
+AR_NDK_URL=https://aaio.eu/ndk/
+AR_NDK_FILE=android-ndk-0-linux-x86_64.tar.bz2
+
+declare -a arr=(
+    "sdk-repo-linux-tools-26.1.1.zip" # Includes sdkmanager
+    "sdk-repo-linux-platforms-eng.11.0.0_r27.zip" # To compile ics-openvpn
+    "sdk-repo-linux-platforms-eng.10.0.0_r36.zip" # To compile eduvpn
+    "sdk-repo-linux-platform-tools-eng.10.0.0_r14.zip" # Contains tools like adb and fastboot
+    "sdk-repo-linux-build-tools-eng.10.0.0_r14.zip" # Contains tools like apksigner
+)
+
+# Creating necessary folder structure
+(
+    mkdir -p "${AR_SDK_DIR}" "${AR_SDK_DIR}"/platforms "${AR_SDK_DIR}"/build-tools "${AR_SDK_DIR}"/ndk "${AR_SDK_DIR}"/ndk/21.4.0
+)
+
+# Downloading and extracting SDK
+(
+    cd "${AR_SDK_DIR}" || exit
+    for i in "${arr[@]}"
+    do
+        echo "Downloading $i"
+        curl -L -O ${AR_SDK_URL}/$i
+        echo "Unzipping $i"
+        unzip -o -q $i -d ${AR_SDK_DIR} | pv -l > /dev/null
+        rm $i
+        # Some of these zips need to be either placed in subfolders or have to be
+        # renamed due to gradle warnings
+        if [ $i = sdk-repo-linux-tools-26.1.1.zip ]
+        then
+            mv tools/ cmdline-tools/
+        elif [ $i = sdk-repo-linux-build-tools-eng.10.0.0_r14.zip ]
+        then
+            mv android-10/ build-tools/29.0.2
+        elif [ $i = sdk-repo-linux-platforms-eng.10.0.0_r36.zip ]
+        then
+            mv android-10/ platforms/android-29
+        elif [ $i = sdk-repo-linux-platforms-eng.11.0.0_r27.zip ]
+        then
+            mv android-11/ platforms/android-30
+        fi
+        echo "Content of $i in place"
+        echo ""
+    done
+)
+
+# Downloading and extracting NDK
+(
+    echo "Downloading ${AR_NDK_FILE}. This might take a while depending on your connection"
+    curl -L -O ${AR_NDK_URL}/${AR_NDK_FILE}
+    echo "Extracting ${AR_NDK_FILE}. This might take a while depending on your system."
+    pv ${AR_NDK_FILE} | tar xj
+    rm ${AR_NDK_FILE}
+    cp -rlf android-ndk-r21e/* "${AR_SDK_DIR}"/ndk/21.4.0/
+    rm -rf android-ndk-r21e/
+    echo "Content of ${AR_NDK_FILE} in place"
+    echo ""
+)

--- a/patches/android-rebuilds/ar.patch
+++ b/patches/android-rebuilds/ar.patch
@@ -1,0 +1,33 @@
+--- a/app/build.gradle     2021-05-24 21:29:18.351474326 +0200
++++ b/app/build.gradle       2021-05-24 21:29:43.974623578 +0200
+@@ -14,7 +14,7 @@
+         targetSdkVersion 29
+         versionCode 17
+         versionName "2.0.4"
+-        ndkVersion "21.0.6113669"
++        ndkVersion "21.4.0"
+ 
+         vectorDrawables.useSupportLibrary = true
+ 
+--- a/ics-openvpn/main/build.gradle.kts    2021-05-24 21:29:18.357474354 +0200
++++ b/ics-openvpn/main/build.gradle.kts      2021-05-24 21:30:57.487003822 +0200
+@@ -22,9 +22,11 @@
+         targetSdkVersion(30)  //'Q'.toInt()
+         versionCode = 176
+         versionName = "0.7.22"
++        ndkVersion = "21.4.0"
+ 
+         externalNativeBuild {
+             cmake {
++                version = "3.10.3+"
+                 //arguments = listOf("-DANDROID_TOOLCHAIN=clang",
+                 //        "-DANDROID_STL=c++_static")
+             }
+@@ -36,6 +38,7 @@
+ 
+     externalNativeBuild {
+         cmake {
++            version = "3.10.3+"
+             path =File("${projectDir}/src/main/cpp/CMakeLists.txt")
+         }
+     }


### PR DESCRIPTION
For context see https://github.com/eduvpn/android/pull/327

I have redone the builder_setup.sh script so it downloads either Google's distribution of the Android SDK or Android Rebuilds' distro based on an argument you pass the script which can be:
- nothing: will download Google's SDK, undoes Android-Rebuilds' patches
- ```google```: see "nothing"
- ```ar```: will download AR's SDK, patches the current repo using the patches in the "patches" folder
- ```ar_patch```: patches the current repo like ```ar``` does, but does not redownload the SDK
- ```ar_undo_patch```: undoes patches done by ```ar_patch``` or ```ar``` like google does without redownloading the SDK

The changes in the PR does not break the build if you want to use sdkmanager, but still leaves you with the choice of using either/or. The build_app_git and build_app_tar scripts are also functional with both choices.