### PR TITLE
Renew session

### DIFF
--- a/app/src/androidTest/java/nl/eduvpn/app/service/HistoryServiceTest.java
+++ b/app/src/androidTest/java/nl/eduvpn/app/service/HistoryServiceTest.java
@@ -17,10 +17,18 @@
 
 package nl.eduvpn.app.service;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.net.Uri;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
 
 import net.openid.appauth.AuthState;
 import net.openid.appauth.AuthorizationServiceConfiguration;
@@ -32,21 +40,16 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.Random;
 
-import androidx.test.core.app.ApplicationProvider;
-import androidx.test.ext.junit.runners.AndroidJUnit4;
-import androidx.test.filters.LargeTest;
+import kotlin.Pair;
 import nl.eduvpn.app.entity.AuthorizationType;
 import nl.eduvpn.app.entity.Instance;
 import nl.eduvpn.app.entity.KeyPair;
 import nl.eduvpn.app.entity.Profile;
 import nl.eduvpn.app.entity.SavedKeyPair;
 import nl.eduvpn.app.entity.SavedProfile;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 
 /**
  * Tests for the history service.
@@ -104,7 +107,7 @@ public class HistoryServiceTest {
             Profile profile = new Profile("displayName", profileId);
             SavedProfile savedProfile = new SavedProfile(instance, profile, profileUUID);
             _historyService.cacheSavedProfile(savedProfile);
-            _historyService.cacheAuthorizationState(instance, new AuthState());
+            _historyService.cacheAuthorizationState(instance, new AuthState(), new Date());
         }
         _reloadHistoryService(false);
         assertEquals(10, _historyService.getSavedProfileList().size());
@@ -117,14 +120,19 @@ public class HistoryServiceTest {
     @Test
     public void testCacheAccessToken() {
         String baseURI = "http://example.com";
-        AuthState exampleAuthState = new AuthState(new AuthorizationServiceConfiguration(Uri.parse("http://example.com/auth"), Uri.parse("http://example.com/token"), null));
+        AuthState exampleAuthState = new AuthState(new AuthorizationServiceConfiguration(Uri.parse("http://example.com/auth"), Uri
+                .parse("http://example.com/token"), null));
         Instance instance = new Instance(baseURI, "displayName", null, AuthorizationType.Distributed, "HU", true, "https://eduvpn.org/template", new ArrayList<>());
-        _historyService.cacheAuthorizationState(instance, exampleAuthState);
+        Date now = new Date();
+        _historyService.cacheAuthorizationState(instance, exampleAuthState, now);
         _reloadHistoryService(false);
-        AuthState restoredAuthState = _historyService.getCachedAuthState(instance);
+        Pair<AuthState, Date> restoredAuthStateWithDate = _historyService.getCachedAuthState(instance);
+        AuthState restoredAuthState = restoredAuthStateWithDate.getFirst();
         //noinspection ConstantConditions
-        assertEquals(exampleAuthState.getAuthorizationServiceConfiguration().authorizationEndpoint, restoredAuthState.getAuthorizationServiceConfiguration().authorizationEndpoint);
-        assertEquals(exampleAuthState.getAuthorizationServiceConfiguration().tokenEndpoint, restoredAuthState.getAuthorizationServiceConfiguration().tokenEndpoint);
+        assertEquals(exampleAuthState.getAuthorizationServiceConfiguration().authorizationEndpoint, restoredAuthState
+                .getAuthorizationServiceConfiguration().authorizationEndpoint);
+        assertEquals(exampleAuthState.getAuthorizationServiceConfiguration().tokenEndpoint, restoredAuthState
+                .getAuthorizationServiceConfiguration().tokenEndpoint);
     }
 
     @Test

--- a/app/src/androidTest/java/nl/eduvpn/app/service/SerializerServiceTest.java
+++ b/app/src/androidTest/java/nl/eduvpn/app/service/SerializerServiceTest.java
@@ -17,8 +17,13 @@
 
 package nl.eduvpn.app.service;
 
+import static org.junit.Assert.assertEquals;
+
 import android.net.Uri;
 import android.util.Pair;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
 
 import net.openid.appauth.AuthState;
 import net.openid.appauth.AuthorizationServiceConfiguration;
@@ -40,8 +45,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
 
-import androidx.test.ext.junit.runners.AndroidJUnit4;
-import androidx.test.filters.LargeTest;
 import nl.eduvpn.app.entity.AuthorizationType;
 import nl.eduvpn.app.entity.DiscoveredAPI;
 import nl.eduvpn.app.entity.Instance;
@@ -59,8 +62,6 @@ import nl.eduvpn.app.entity.message.Maintenance;
 import nl.eduvpn.app.entity.message.Message;
 import nl.eduvpn.app.entity.message.Notification;
 import nl.eduvpn.app.utils.TTLCache;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * Unit tests for the serializer service.
@@ -190,8 +191,8 @@ public class SerializerServiceTest {
         Instance instance2 = new Instance("baseUri2", "displayName2", null, AuthorizationType.Local, "FR", true, null, new ArrayList<>());
         AuthState state1 = new AuthState(new AuthorizationServiceConfiguration(Uri.parse("http://eduvpn.org/auth"), Uri.parse("http://eduvpn.org/token"), null));
         AuthState state2 = new AuthState(new AuthorizationServiceConfiguration(Uri.parse("http://example.com/auth"), Uri.parse("http://example.com/token"), null));
-        SavedAuthState token1 = new SavedAuthState(instance1, state1);
-        SavedAuthState token2 = new SavedAuthState(instance2, state2);
+        SavedAuthState token1 = new SavedAuthState(instance1, state1, new Date());
+        SavedAuthState token2 = new SavedAuthState(instance2, state2, new Date());
         List<SavedAuthState> list = Arrays.asList(token1, token2);
         JSONObject serializedList = _serializerService.serializeSavedAuthStateList(list);
         List<SavedAuthState> deserializedList = _serializerService.deserializeSavedAuthStateList(serializedList);

--- a/app/src/main/java/nl/eduvpn/app/MainActivity.java
+++ b/app/src/main/java/nl/eduvpn/app/MainActivity.java
@@ -23,15 +23,16 @@ import android.os.Bundle;
 import android.view.MenuItem;
 import android.widget.Toast;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.ActionBar;
+import androidx.fragment.app.Fragment;
+
 import net.openid.appauth.AuthorizationException;
 import net.openid.appauth.AuthorizationResponse;
 
 import javax.inject.Inject;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.appcompat.app.ActionBar;
-import androidx.fragment.app.Fragment;
 import nl.eduvpn.app.base.BaseActivity;
 import nl.eduvpn.app.databinding.ActivityMainBinding;
 import nl.eduvpn.app.fragment.AddServerFragment;
@@ -149,8 +150,8 @@ public class MainActivity extends BaseActivity<ActivityMainBinding> {
             Fragment currentFragment = getSupportFragmentManager().findFragmentById(R.id.content_frame);
             ConnectionService.AuthorizationStateCallback callback = () -> {
                 if (currentFragment instanceof ServerSelectionFragment) {
-                    ((ServerSelectionFragment)currentFragment).connectToSelectedInstance();
-                } else {
+                    ((ServerSelectionFragment) currentFragment).connectToSelectedInstance();
+                } else if (currentFragment instanceof OrganizationSelectionFragment) {
                     Toast.makeText(this, R.string.provider_added_new_configs_available, Toast.LENGTH_LONG).show();
                 }
             };
@@ -159,7 +160,9 @@ public class MainActivity extends BaseActivity<ActivityMainBinding> {
             // Remove it so we don't parse it again.
             intent.setData(null);
 
-            if (!(currentFragment instanceof ConnectionStatusFragment) && !(currentFragment instanceof ServerSelectionFragment)) {
+            if (currentFragment instanceof ConnectionStatusFragment) {
+                ((ConnectionStatusFragment) currentFragment).reconnectToInstance();
+            } else if (!(currentFragment instanceof ServerSelectionFragment)) {
                 openFragment(ServerSelectionFragment.Companion.newInstance(true), false);
             }
 

--- a/app/src/main/java/nl/eduvpn/app/MainActivity.java
+++ b/app/src/main/java/nl/eduvpn/app/MainActivity.java
@@ -31,6 +31,8 @@ import androidx.fragment.app.Fragment;
 import net.openid.appauth.AuthorizationException;
 import net.openid.appauth.AuthorizationResponse;
 
+import java.util.Date;
+
 import javax.inject.Inject;
 
 import nl.eduvpn.app.base.BaseActivity;
@@ -147,6 +149,7 @@ public class MainActivity extends BaseActivity<ActivityMainBinding> {
                     authorizationException.code,
                     authorizationException.getMessage()));
         } else {
+            Date authenticationDate = new Date();
             Fragment currentFragment = getSupportFragmentManager().findFragmentById(R.id.content_frame);
             ConnectionService.AuthorizationStateCallback callback = () -> {
                 if (currentFragment instanceof ServerSelectionFragment) {
@@ -155,7 +158,7 @@ public class MainActivity extends BaseActivity<ActivityMainBinding> {
                     Toast.makeText(this, R.string.provider_added_new_configs_available, Toast.LENGTH_LONG).show();
                 }
             };
-            _connectionService.parseAuthorizationResponse(authorizationResponse, this, callback);
+            _connectionService.parseAuthorizationResponse(authorizationResponse, this, callback, authenticationDate);
 
             // Remove it so we don't parse it again.
             intent.setData(null);

--- a/app/src/main/java/nl/eduvpn/app/entity/SavedAuthState.kt
+++ b/app/src/main/java/nl/eduvpn/app/entity/SavedAuthState.kt
@@ -17,6 +17,7 @@
 package nl.eduvpn.app.entity
 
 import net.openid.appauth.AuthState
+import java.util.*
 
 /**
  * Stores the mapping between the base URI and the authorization state containing the current and refresh tokens.
@@ -24,5 +25,10 @@ import net.openid.appauth.AuthState
  *
  * @param instance  The VPN provider the token is valid for.
  * @param authState The authorization state with the tokens.
+ * @param authenticationDate Date when application received authentication state.
  */
-data class SavedAuthState(val instance: Instance, var authState: AuthState)
+data class SavedAuthState(
+    val instance: Instance,
+    var authState: AuthState,
+    val authenticationDate: Date?,
+)

--- a/app/src/main/java/nl/eduvpn/app/entity/SavedAuthState.kt
+++ b/app/src/main/java/nl/eduvpn/app/entity/SavedAuthState.kt
@@ -14,39 +14,15 @@
  *     You should have received a copy of the GNU General Public License
  *     along with eduVPN.  If not, see <http://www.gnu.org/licenses/>.
  */
+package nl.eduvpn.app.entity
 
-package nl.eduvpn.app.entity;
-
-import net.openid.appauth.AuthState;
+import net.openid.appauth.AuthState
 
 /**
  * Stores the mapping between the base URI and the authorization state containing the current and refresh tokens.
  * Created by Daniel Zolnai on 2016-10-20.
+ *
+ * @param instance  The VPN provider the token is valid for.
+ * @param authState The authorization state with the tokens.
  */
-public class SavedAuthState {
-    private Instance _instance;
-    private AuthState _authState;
-
-    /**
-     * Constructor.
-     *
-     * @param instance  The VPN provider the token is valid for.
-     * @param authState The authorization state with the tokens..
-     */
-    public SavedAuthState(Instance instance, AuthState authState) {
-        _instance = instance;
-        _authState = authState;
-    }
-
-    public Instance getInstance() {
-        return _instance;
-    }
-
-    public AuthState getAuthState() {
-        return _authState;
-    }
-
-    public void setAuthState(AuthState authState) {
-        _authState = authState;
-    }
-}
+data class SavedAuthState(val instance: Instance, var authState: AuthState)

--- a/app/src/main/java/nl/eduvpn/app/fragment/ServerSelectionFragment.kt
+++ b/app/src/main/java/nl/eduvpn/app/fragment/ServerSelectionFragment.kt
@@ -95,10 +95,10 @@ class ServerSelectionFragment : BaseFragment<FragmentServerSelectionBinding>() {
             val item = adapter.getItem(position)
             if (item is OrganizationAdapter.OrganizationAdapterItem.SecureInternet) {
                 viewModel.connectingTo.value = item.server
-                viewModel.discoverApi(item.server, null)
+                viewModel.discoverApi(item.server)
             } else if (item is OrganizationAdapter.OrganizationAdapterItem.InstituteAccess) {
                 viewModel.connectingTo.value = item.server
-                viewModel.discoverApi(item.server, null)
+                viewModel.discoverApi(item.server)
             }
         }.setOnItemLongClickListener { _, position, _ ->
             val item = adapter.getItem(position)

--- a/app/src/main/java/nl/eduvpn/app/service/SerializerService.java
+++ b/app/src/main/java/nl/eduvpn/app/service/SerializerService.java
@@ -19,6 +19,8 @@ package nl.eduvpn.app.service;
 
 import android.util.Pair;
 
+import androidx.annotation.NonNull;
+
 import net.openid.appauth.AuthState;
 
 import org.json.JSONArray;
@@ -37,7 +39,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
 
-import androidx.annotation.NonNull;
 import nl.eduvpn.app.Constants;
 import nl.eduvpn.app.entity.AuthorizationType;
 import nl.eduvpn.app.entity.DiscoveredAPI;
@@ -528,7 +529,12 @@ public class SerializerService {
             for (SavedAuthState savedAuthState : savedAuthStateList) {
                 JSONObject authStateJson = new JSONObject();
                 authStateJson.put("instance", serializeInstance(savedAuthState.getInstance()));
-                authStateJson.put("auth_state", savedAuthState.getAuthState().jsonSerializeString());
+                authStateJson.put("auth_state", savedAuthState.getAuthState()
+                        .jsonSerializeString());
+                Date authenticationDate = savedAuthState.getAuthenticationDate();
+                if (authenticationDate != null) {
+                    authStateJson.put("authentication_date", authenticationDate.getTime());
+                }
                 array.put(authStateJson);
             }
             result.put("data", array);
@@ -554,7 +560,12 @@ public class SerializerService {
                 Instance instance = deserializeInstance(tokenObject.getJSONObject("instance"));
                 String authStateString = tokenObject.getString("auth_state");
                 AuthState authState = AuthState.jsonDeserialize(authStateString);
-                result.add(new SavedAuthState(instance, authState));
+                Date authenticationDate = null;
+                if (tokenObject.has("authentication_date")) {
+                    long authenticationTimestamp = tokenObject.getLong("authentication_date");
+                    authenticationDate = new Date(authenticationTimestamp);
+                }
+                result.add(new SavedAuthState(instance, authState, authenticationDate));
             }
             return result;
         } catch (JSONException ex) {

--- a/app/src/main/java/nl/eduvpn/app/viewmodel/BaseConnectionViewModel.kt
+++ b/app/src/main/java/nl/eduvpn/app/viewmodel/BaseConnectionViewModel.kt
@@ -91,7 +91,11 @@ abstract class BaseConnectionViewModel(
                             preferencesService.currentInstance = instance
                             preferencesService.currentDiscoveredAPI = discoveredAPI
                             preferencesService.currentAuthState = savedToken.authState
-                            historyService.cacheAuthorizationState(instance, savedToken.authState)
+                            historyService.cacheAuthorizationState(
+                                instance,
+                                savedToken.authState,
+                                null
+                            )
                         }
                         fetchProfiles(instance, discoveredAPI, savedToken.authState)
                     }
@@ -171,7 +175,7 @@ abstract class BaseConnectionViewModel(
     fun selectProfileToConnectTo(profile: Profile) {
         // We surely have a discovered API and access token, since we just loaded the list with them
         val instance = preferencesService.currentInstance
-        val authState = historyService.getCachedAuthState(instance!!)
+        val authState = historyService.getCachedAuthState(instance!!)?.first
         val discoveredAPI = preferencesService.currentDiscoveredAPI
         if (authState == null || discoveredAPI == null) {
             Log.e(TAG, "Unable to connect. Auth state OK: ${authState != null}, discovered API OK: ${discoveredAPI != null}")

--- a/app/src/main/java/nl/eduvpn/app/viewmodel/BaseConnectionViewModel.kt
+++ b/app/src/main/java/nl/eduvpn/app/viewmodel/BaseConnectionViewModel.kt
@@ -67,9 +67,12 @@ abstract class BaseConnectionViewModel(
     val warning = MutableLiveData<String>()
 
     val parentAction = MutableLiveData<ParentAction>()
-
-
-    fun discoverApi(instance: Instance, parentInstance: Instance? = null) {
+    
+    fun discoverApi(
+        instance: Instance,
+        parentInstance: Instance? = null,
+        reauthorize: Boolean = false
+    ) {
         // If no discovered API, fetch it first, then initiate the connection for the login
         connectionState.value = ConnectionState.DiscoveringApi
         // Discover the API
@@ -80,7 +83,7 @@ abstract class BaseConnectionViewModel(
                 try {
                     val discoveredAPI = serializerService.deserializeDiscoveredAPI(result)
                     val savedToken = historyService.getSavedToken(parentInstance ?: instance)
-                    if (savedToken == null) {
+                    if (savedToken == null || reauthorize) {
                         authorize(parentInstance ?: instance, discoveredAPI)
                     } else {
                         if (savedToken.instance.sanitizedBaseURI != (parentInstance

--- a/app/src/main/java/nl/eduvpn/app/viewmodel/BaseConnectionViewModel.kt
+++ b/app/src/main/java/nl/eduvpn/app/viewmodel/BaseConnectionViewModel.kt
@@ -94,7 +94,7 @@ abstract class BaseConnectionViewModel(
                             historyService.cacheAuthorizationState(
                                 instance,
                                 savedToken.authState,
-                                null
+                                savedToken.authenticationDate
                             )
                         }
                         fetchProfiles(instance, discoveredAPI, savedToken.authState)

--- a/app/src/main/java/nl/eduvpn/app/viewmodel/BaseConnectionViewModel.kt
+++ b/app/src/main/java/nl/eduvpn/app/viewmodel/BaseConnectionViewModel.kt
@@ -68,26 +68,24 @@ abstract class BaseConnectionViewModel(
 
     val parentAction = MutableLiveData<ParentAction>()
     
-    fun discoverApi(
-        instance: Instance,
-        parentInstance: Instance? = null,
-        reauthorize: Boolean = false
-    ) {
+    fun discoverApi(instance: Instance, reauthorize: Boolean = false) {
         // If no discovered API, fetch it first, then initiate the connection for the login
         connectionState.value = ConnectionState.DiscoveringApi
         // Discover the API
         viewModelScope.launch(Dispatchers.Main) {
             runCatchingCoroutine {
-                apiService.getJSON(instance.sanitizedBaseURI + Constants.API_DISCOVERY_POSTFIX, null)
+                apiService.getJSON(
+                    instance.sanitizedBaseURI + Constants.API_DISCOVERY_POSTFIX,
+                    null
+                )
             }.onSuccess { result ->
                 try {
                     val discoveredAPI = serializerService.deserializeDiscoveredAPI(result)
-                    val savedToken = historyService.getSavedToken(parentInstance ?: instance)
+                    val savedToken = historyService.getSavedToken(instance)
                     if (savedToken == null || reauthorize) {
-                        authorize(parentInstance ?: instance, discoveredAPI)
+                        authorize(instance, discoveredAPI)
                     } else {
-                        if (savedToken.instance.sanitizedBaseURI != (parentInstance
-                                        ?: instance).sanitizedBaseURI) {
+                        if (savedToken.instance.sanitizedBaseURI != instance.sanitizedBaseURI) {
                             // This is a distributed token. We add it to the list.
                             Log.i(TAG, "Distributed token found for different instance.")
                             preferencesService.currentInstance = instance

--- a/app/src/main/java/nl/eduvpn/app/viewmodel/ConnectionStatusViewModel.kt
+++ b/app/src/main/java/nl/eduvpn/app/viewmodel/ConnectionStatusViewModel.kt
@@ -97,7 +97,7 @@ class ConnectionStatusViewModel @Inject constructor(
     }
 
     fun renewSession() {
-        discoverApi(preferencesService.currentInstance, null, true)
+        discoverApi(preferencesService.currentInstance, true)
     }
 
     fun reconnectToInstance() {

--- a/app/src/main/java/nl/eduvpn/app/viewmodel/ConnectionStatusViewModel.kt
+++ b/app/src/main/java/nl/eduvpn/app/viewmodel/ConnectionStatusViewModel.kt
@@ -21,6 +21,7 @@ package nl.eduvpn.app.viewmodel
 import android.content.Context
 import android.text.Spanned
 import androidx.core.text.HtmlCompat
+import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.liveData
 import de.blinkt.openvpn.VpnProfile
@@ -34,6 +35,7 @@ import nl.eduvpn.app.livedata.UnlessDisconnectedLiveData
 import nl.eduvpn.app.service.*
 import nl.eduvpn.app.utils.getCountryText
 import nl.eduvpn.app.utils.toSingleEvent
+import java.util.*
 import javax.inject.Inject
 
 class ConnectionStatusViewModel @Inject constructor(
@@ -68,6 +70,7 @@ class ConnectionStatusViewModel @Inject constructor(
     val connectionTimeLiveData = ConnectionTimeLiveData.create(vpnService, timer)
     val byteCountLiveData = UnlessDisconnectedLiveData.create(ByteCountLiveData(), vpnService)
     val ipLiveData = IPLiveData()
+    val canRenew: LiveData<Boolean>
 
     private val _connectionParentAction = MutableLiveData<ParentAction>()
     val connectionParentAction = _connectionParentAction.toSingleEvent()
@@ -90,9 +93,30 @@ class ConnectionStatusViewModel @Inject constructor(
             }
             // Remove the last separator
             supportContacts.delete(supportContacts.length - 2, supportContacts.length)
-            serverSupport.value = context.getString(R.string.connection_info_support, supportContacts)
+            serverSupport.value =
+                context.getString(R.string.connection_info_support, supportContacts)
         } else {
             serverSupport.value = null
+        }
+
+        val authenticationDate =
+            historyService.getCachedAuthState(preferencesService.currentInstance)?.second
+        canRenew = if (authenticationDate == null) {
+            MutableLiveData(true)
+        } else {
+            val now = Date().time
+            val millisecondAmountOf30Minutes = 30 * 60 * 1000
+            val canRenewAt = authenticationDate.time + millisecondAmountOf30Minutes
+            val remaining = canRenewAt - now
+            if (remaining > 0) {
+                liveData {
+                    emit(false)
+                    delay(remaining)
+                    emit(true)
+                }
+            } else {
+                MutableLiveData(true)
+            }
         }
     }
 

--- a/app/src/main/res/layout/fragment_connection_status.xml
+++ b/app/src/main/res/layout/fragment_connection_status.xml
@@ -123,7 +123,8 @@
                 android:gravity="center"
                 android:text="@string/connection_info_renew_session"
                 android:textColor="@color/textColorLink"
-                android:textSize="14sp" />
+                android:textSize="14sp"
+                android:visibility="@{viewModel.canRenew ? View.VISIBLE : View.GONE}" />
 
             <androidx.appcompat.widget.SwitchCompat
                 android:id="@+id/connection_switch"

--- a/app/src/main/res/layout/fragment_connection_status.xml
+++ b/app/src/main/res/layout/fragment_connection_status.xml
@@ -40,7 +40,7 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_marginBottom="96dp"
+            android:layout_marginBottom="64dp"
             android:baselineAligned="false"
             android:gravity="center"
             android:orientation="vertical">
@@ -111,6 +111,19 @@
                 android:textColor="@color/textColor"
                 android:textSize="14sp"
                 tools:text="Valid for 13 days and 22 hours" />
+
+            <TextView
+                android:id="@+id/renew_session"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="32dp"
+                android:layout_marginTop="8dp"
+                android:layout_marginRight="32dp"
+                android:fontFamily="@font/open_sans_regular"
+                android:gravity="center"
+                android:text="@string/connection_info_renew_session"
+                android:textColor="@color/textColorLink"
+                android:textSize="14sp" />
 
             <androidx.appcompat.widget.SwitchCompat
                 android:id="@+id/connection_switch"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -9,6 +9,7 @@
     <color name="textColor">#101010</color>
     <color name="settingsTextColor">#505050</color>
     <color name="textColorInverted">#FFFFFF</color>
+    <color name="textColorLink">#216aed</color>
     <color name="buttonTextColor">#FFFFFF</color>
     <color name="switcherButtonTextColor">#101010</color>
     <color name="disabledColor">#E0E0E0</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -191,4 +191,5 @@
     <string name="error_organization_list_version_check_title">Problem downloading organization list</string>
     <string name="error_server_list_version_check_message">Server list version is outdated.</string>
     <string name="error_server_list_version_check_title">Problem downloading server list</string>
+    <string name="connection_info_renew_session">Renew Session</string>
 </resources>


### PR DESCRIPTION
Implements a renew session link that allows the user to renew the certificate at any time. The renew session link is always shown, this differs from the iOS app where the renew session link is not shown when the VPN is disconnected or when there are multiple profiles to choose from.

<img alt="Screenshot eduVPN with renew session link" src="https://user-images.githubusercontent.com/3309700/130612728-d8262b62-03e5-4c18-a928-f5f67832f796.png" width="300">

There is a bug: if a user presses the renew session link within 30 minutes of a previous login, the user is still logged in, and when approving the application again the certificate expiry time is not changed. The user has to log out first for this to happen. There is no way to force a logout and opening the browser in incognito on Android is also not possible.

When pressing the renew session link the VPN is automatically disconnected, but when switching profiles the user gets a notification telling the user to disconnect the VPN first. Do we want the same behaviour with the renew session link:  show a notification when the VPN is connected and the user presses the renew session link?

This pull request includes https://github.com/eduvpn/android/pull/342.