### PR TITLE
Use  /.well-known/vpn-user-portal instead of /info.json

### DIFF
--- a/app/src/main/java/nl/eduvpn/app/Constants.java
+++ b/app/src/main/java/nl/eduvpn/app/Constants.java
@@ -30,7 +30,7 @@ public class Constants {
 
     public static final Uri HELP_URI = Uri.parse("https://www.eduvpn.org/faq.html");
 
-    public static final String API_DISCOVERY_POSTFIX = "/info.json";
+    public static final String API_DISCOVERY_POSTFIX = "/.well-known/vpn-user-portal";
 
     public static final String API_SYSTEM_MESSAGES_PATH = "system_messages";
     public static final String API_USER_MESSAGES_PATH = "user_messages";


### PR DESCRIPTION
/info.json is being phased out: https://github.com/eduvpn/documentation/commit/b2b3270b63adbb2dab00c4f20b4720e125dcb637#diff-abb4e8748bf4ce8b7d6b2e49f17270893adae77c5bace331ae9eb614a3c727c9R54