### PR TITLE
Remove secure-preferences

### DIFF
--- a/app/src/androidTest/java/nl/eduvpn/app/service/HistoryServiceTest.kt
+++ b/app/src/androidTest/java/nl/eduvpn/app/service/HistoryServiceTest.kt
@@ -18,7 +18,6 @@ package nl.eduvpn.app.service
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.content.SharedPreferences
 import android.net.Uri
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -47,18 +46,6 @@ class HistoryServiceTest {
         reloadHistoryService(true)
     }
 
-    companion object {
-        lateinit var securePreferences: SharedPreferences
-
-        @JvmStatic
-        @BeforeClass
-        fun setPreferences() {
-            val context = ApplicationProvider.getApplicationContext<Context>()
-            @Suppress("DEPRECATION")
-            securePreferences = SecurityService(context).securePreferences
-        }
-    }
-
     /**
      * Reloads the service, so we can test if the (de)serialization works as expected.
      *
@@ -68,8 +55,7 @@ class HistoryServiceTest {
     private fun reloadHistoryService(clearHistory: Boolean) {
         val serializerService = SerializerService()
         val context = ApplicationProvider.getApplicationContext<Context>()
-        val preferencesService =
-            PreferencesService(context, serializerService, securePreferences)
+        val preferencesService = PreferencesService(context, serializerService)
         // Clean the shared preferences if needed
         if (clearHistory) {
             preferencesService.clearPreferences()

--- a/app/src/androidTest/java/nl/eduvpn/app/service/SecurityServiceTest.java
+++ b/app/src/androidTest/java/nl/eduvpn/app/service/SecurityServiceTest.java
@@ -18,21 +18,18 @@
 
 package nl.eduvpn.app.service;
 
-import android.content.Context;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.io.IOException;
-
-import androidx.test.core.app.ApplicationProvider;
-import androidx.test.ext.junit.runners.AndroidJUnit4;
-import androidx.test.filters.LargeTest;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 @RunWith(AndroidJUnit4.class)
 @LargeTest
@@ -48,8 +45,7 @@ public class SecurityServiceTest {
 
     @Before
     public void before() {
-        Context context = ApplicationProvider.getApplicationContext();
-        _securityService = new SecurityService(context);
+        _securityService = new SecurityService();
         SecurityService.loadMinisignPublicKeys(UNIT_TEST_PUBLIC_KEYS);
     }
 

--- a/app/src/main/java/nl/eduvpn/app/inject/ApplicationModule.kt
+++ b/app/src/main/java/nl/eduvpn/app/inject/ApplicationModule.kt
@@ -17,7 +17,6 @@
 package nl.eduvpn.app.inject
 
 import android.content.Context
-import android.content.SharedPreferences
 import android.os.Build
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.liveData
@@ -69,19 +68,11 @@ class ApplicationModule(private val application: EduVPNApplication) {
 
     @Provides
     @Singleton
-    fun provideSecurePreferences(securityService: SecurityService): SharedPreferences {
-        @Suppress("DEPRECATION")
-        return securityService.securePreferences
-    }
-
-    @Provides
-    @Singleton
     fun providePreferencesService(
         context: Context,
         serializerService: SerializerService,
-        sharedPreferences: SharedPreferences
     ): PreferencesService {
-        return PreferencesService(context, serializerService, sharedPreferences)
+        return PreferencesService(context, serializerService)
     }
 
     @Provides
@@ -181,8 +172,8 @@ class ApplicationModule(private val application: EduVPNApplication) {
 
     @Provides
     @Singleton
-    fun provideSecurityService(context: Context?): SecurityService {
-        return SecurityService(context)
+    fun provideSecurityService(): SecurityService {
+        return SecurityService()
     }
 
     @Provides

--- a/app/src/main/java/nl/eduvpn/app/service/SecurityService.java
+++ b/app/src/main/java/nl/eduvpn/app/service/SecurityService.java
@@ -17,11 +17,12 @@
 
 package nl.eduvpn.app.service;
 
-import android.content.Context;
-import android.content.SharedPreferences;
 import android.util.Base64;
 
-import com.securepreferences.SecurePreferences;
+import androidx.annotation.CheckResult;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 
 import org.libsodium.jni.NaCl;
 import org.libsodium.jni.Sodium;
@@ -34,10 +35,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import androidx.annotation.CheckResult;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.VisibleForTesting;
 import nl.eduvpn.app.BuildConfig;
 import nl.eduvpn.app.utils.Log;
 
@@ -68,11 +65,7 @@ public class SecurityService {
         NaCl.sodium();
     }
 
-    private final Context _context;
-
-
-    public SecurityService(Context context) {
-        _context = context;
+    public SecurityService() {
         loadMinisignPublicKeys(BuildConfig.MINISIGN_SIGNATURE_VALIDATION_PUBLIC_KEY);
     }
 
@@ -94,16 +87,6 @@ public class SecurityService {
         }
         MINISIGN_PUBLIC_KEY_ID_LIST = Collections.unmodifiableList(idList);
         MINISIGN_PUBLIC_KEY_BYTES_LIST = Collections.unmodifiableList(bytesList);
-    }
-
-    /**
-     * @deprecated This will be removed in favor of the regular preferences. Currently
-     * we migrate all data over from these preferences to the regular if we detect any data in this one.
-     * This method will be probably removed in 1.4 or 1.5. For more info, see: https://github.com/eduvpn/android/issues/117
-     */
-    @Deprecated
-    public SharedPreferences getSecurePreferences() {
-        return new SecurePreferences(_context);
     }
 
     @CheckResult


### PR DESCRIPTION
Fixes https://github.com/eduvpn/android/issues/117

When upgrading to this version from eduVPN < 1.3.0, all data will be removed instead of migrated.

Tested on Android 11 and Android 5