### PR TITLE
Disable autoLink for cert validity

### DIFF
--- a/app/src/main/res/layout/fragment_connection_status.xml
+++ b/app/src/main/res/layout/fragment_connection_status.xml
@@ -105,7 +105,6 @@
                 android:layout_marginLeft="32dp"
                 android:layout_marginTop="8dp"
                 android:layout_marginRight="32dp"
-                android:autoLink="all"
                 android:fontFamily="@font/open_sans_regular"
                 android:gravity="center"
                 android:text="@{viewModel.certValidity}"


### PR DESCRIPTION
Currently, the remaining validity has `autoLink` set, which converts the numbers into a link that opens the phone app when clicked. This PR should fix that behavior.

<img alt="Screenshot of eduVPN with numbers incorrectly linked" src="https://github.com/eduvpn/android/assets/719105/afc5219a-213a-4234-abea-021ffdbf8c05" width=300>