### PR TITLE
Update common, Proxyguard support

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,3 +1,6 @@
+# This will allow us to get the correct file line numbers to the errors
+-keepattributes SourceFile,LineNumberTable
+
 -dontwarn com.google.errorprone.annotations.*
 -dontwarn org.bouncycastle.jsse.**
 -dontwarn org.conscrypt.*

--- a/app/src/androidTest/java/nl/eduvpn/app/service/SerializerServiceTest.java
+++ b/app/src/androidTest/java/nl/eduvpn/app/service/SerializerServiceTest.java
@@ -62,12 +62,12 @@ public class SerializerServiceTest {
         Settings settings = new Settings(true, true);
         JSONObject jsonObject = _serializerService.serializeAppSettings(settings);
         Settings deserializedSettings = _serializerService.deserializeAppSettings(jsonObject);
-        assertEquals(settings.forceTcp(), deserializedSettings.forceTcp());
+        assertEquals(settings.preferTcp(), deserializedSettings.preferTcp());
         assertEquals(settings.useCustomTabs(), deserializedSettings.useCustomTabs());
         settings = new Settings(false, false);
         jsonObject = _serializerService.serializeAppSettings(settings);
         deserializedSettings = _serializerService.deserializeAppSettings(jsonObject);
-        assertEquals(settings.forceTcp(), deserializedSettings.forceTcp());
+        assertEquals(settings.preferTcp(), deserializedSettings.preferTcp());
         assertEquals(settings.useCustomTabs(), deserializedSettings.useCustomTabs());
     }
 

--- a/app/src/main/java/nl/eduvpn/app/MainActivity.kt
+++ b/app/src/main/java/nl/eduvpn/app/MainActivity.kt
@@ -169,7 +169,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>() {
             .setItems(instancesWithNames.map { it.second }.toTypedArray()) { _, which ->
                 val selectedInstance = instancesWithNames[which]
                 selectedInstance.first.countryCode?.let { countryCode ->
-                    viewModel.onCountrySelected(cookie, countryCode)
+                    viewModel.onCountrySelected(cookie, selectedInstance.first.baseURI, countryCode)
                 }
             }.show()
     }

--- a/app/src/main/java/nl/eduvpn/app/MainActivity.kt
+++ b/app/src/main/java/nl/eduvpn/app/MainActivity.kt
@@ -122,7 +122,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>() {
                 }
 
                 is MainViewModel.MainParentAction.ConnectWithConfig -> {
-                    viewModel.parseConfigAndStartConnection(this, parentAction.config, parentAction.forceTCP)
+                    viewModel.parseConfigAndStartConnection(this, parentAction.config, parentAction.preferTcp)
                     openFragment(ConnectionStatusFragment(), false)
                 }
 

--- a/app/src/main/java/nl/eduvpn/app/entity/CookieAndProfileMapData.kt
+++ b/app/src/main/java/nl/eduvpn/app/entity/CookieAndProfileMapData.kt
@@ -20,7 +20,6 @@ data class ProfileWithoutIdMap(
             Profile(
                 profileId = it.key,
                 displayName = it.value.displayName,
-                vpnProtocolList = it.value.supportedProtocols
             )
         } ?: emptyList()
     }
@@ -32,7 +31,4 @@ data class ProfileWithoutIdMap(
 data class ProfileWithoutId(
     @SerialName("display_name")
     val displayName: TranslatableString,
-
-    @SerialName("supported_protocols")
-    val supportedProtocols: List<Int>,
 )

--- a/app/src/main/java/nl/eduvpn/app/entity/Profile.kt
+++ b/app/src/main/java/nl/eduvpn/app/entity/Profile.kt
@@ -14,7 +14,4 @@ data class Profile (
 
     @SerialName("display_name")
     val displayName: TranslatableString,
-
-    @SerialName("vpn_proto_list")
-    val vpnProtocolList: List<Int>,
 ) : Parcelable

--- a/app/src/main/java/nl/eduvpn/app/entity/SerializedVpnConfig.kt
+++ b/app/src/main/java/nl/eduvpn/app/entity/SerializedVpnConfig.kt
@@ -9,5 +9,7 @@ data class SerializedVpnConfig(
     val config: String,
     val protocol: Int,
     @SerialName("default_gateway")
-    val defaultGateway: Boolean
+    val defaultGateway: Boolean,
+    @SerialName("should_failover")
+    val shouldFailover: Boolean = false
 )

--- a/app/src/main/java/nl/eduvpn/app/entity/SerializedVpnConfig.kt
+++ b/app/src/main/java/nl/eduvpn/app/entity/SerializedVpnConfig.kt
@@ -11,5 +11,14 @@ data class SerializedVpnConfig(
     @SerialName("default_gateway")
     val defaultGateway: Boolean,
     @SerialName("should_failover")
-    val shouldFailover: Boolean = false
+    val shouldFailover: Boolean = false,
+    val proxy: ProxySettings? = null
+)
+
+@Serializable
+data class ProxySettings(
+    @SerialName("source_port")
+    val sourcePort: Int,
+    val listen: String,
+    val peer: String
 )

--- a/app/src/main/java/nl/eduvpn/app/entity/Settings.java
+++ b/app/src/main/java/nl/eduvpn/app/entity/Settings.java
@@ -24,22 +24,22 @@ package nl.eduvpn.app.entity;
 public class Settings {
 
     public static final boolean USE_CUSTOM_TABS_DEFAULT_VALUE = true;
-    public static final boolean FORCE_TCP_DEFAULT_VALUE = false;
+    public static final boolean PREFER_TCP_DEFAULT_VALUE = false;
 
     private boolean _useCustomTabs;
-    private boolean _forceTcp;
+    private boolean _preferTcp;
 
-    public Settings(boolean useCustomTabs, boolean forceTcp) {
+    public Settings(boolean useCustomTabs, boolean preferTcp) {
         _useCustomTabs = useCustomTabs;
-        _forceTcp = forceTcp;
+        _preferTcp = preferTcp;
     }
 
     public boolean useCustomTabs() {
         return _useCustomTabs;
     }
 
-    public boolean forceTcp() {
-        return _forceTcp;
+    public boolean preferTcp() {
+        return _preferTcp;
     }
 
 }

--- a/app/src/main/java/nl/eduvpn/app/fragment/ConnectionStatusFragment.kt
+++ b/app/src/main/java/nl/eduvpn/app/fragment/ConnectionStatusFragment.kt
@@ -204,6 +204,7 @@ class ConnectionStatusFragment : BaseFragment<FragmentConnectionStatusBinding>()
         }
         viewModel.timer.observe(viewLifecycleOwner, updateCertExpiryObserver)
         val vpnStatusObserver = { vpnStatus: VPNStatus ->
+            viewModel.notifyVpnStatus(vpnStatus)
             binding.connectionStatus.setText(VPNConnectionService.vpnStatusToStringID(vpnStatus))
             when (vpnStatus) {
                 VPNStatus.CONNECTED -> {

--- a/app/src/main/java/nl/eduvpn/app/fragment/SettingsFragment.kt
+++ b/app/src/main/java/nl/eduvpn/app/fragment/SettingsFragment.kt
@@ -33,10 +33,7 @@ import nl.eduvpn.app.SettingsActivity
 import nl.eduvpn.app.base.BaseFragment
 import nl.eduvpn.app.databinding.FragmentSettingsBinding
 import nl.eduvpn.app.entity.Settings
-import nl.eduvpn.app.service.HistoryService
-import nl.eduvpn.app.service.PreferencesService
 import nl.eduvpn.app.viewmodel.SettingsViewModel
-import javax.inject.Inject
 
 /**
  * Fragment which displays the available settings to the user.
@@ -53,9 +50,9 @@ class SettingsFragment : BaseFragment<FragmentSettingsBinding>() {
         EduVPNApplication.get(view.context).component().inject(this)
         val originalSettings = viewModel.appSettings
         binding.useCustomTabsSwitch.isChecked = originalSettings.useCustomTabs()
-        binding.forceTcpSwitch.isChecked = originalSettings.forceTcp()
+        binding.preferTcpSwitch.isChecked = originalSettings.preferTcp()
         binding.useCustomTabsSwitch.setOnClickListener { saveSettings() }
-        binding.forceTcpSwitch.setOnClickListener { saveSettings() }
+        binding.preferTcpSwitch.setOnClickListener { saveSettings() }
         binding.licensesButton.setOnClickListener {
             startActivity(
                 Intent(
@@ -114,7 +111,7 @@ class SettingsFragment : BaseFragment<FragmentSettingsBinding>() {
 
     private fun saveSettings() {
         val useCustomTabs = binding.useCustomTabsSwitch.isChecked
-        val forceTcp = binding.forceTcpSwitch.isChecked
-        viewModel.storeAppSettings(Settings(useCustomTabs, forceTcp))
+        val preferTcp = binding.preferTcpSwitch.isChecked
+        viewModel.storeAppSettings(Settings(useCustomTabs, preferTcp))
     }
 }

--- a/app/src/main/java/nl/eduvpn/app/inject/ApplicationModule.kt
+++ b/app/src/main/java/nl/eduvpn/app/inject/ApplicationModule.kt
@@ -32,6 +32,7 @@ import nl.eduvpn.app.utils.Log
 import okhttp3.Cache
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
+import org.eduvpn.common.Protocol
 import java.io.IOException
 import java.net.ConnectException
 import java.net.SocketTimeoutException
@@ -147,8 +148,8 @@ class ApplicationModule(private val application: EduVPNApplication) {
         wireGuardServiceProvider: Provider<WireGuardService>
     ): Optional<VPNService> {
         return when (preferencesService.getCurrentProtocol()) {
-            org.eduvpn.common.Protocol.OpenVPN.nativeValue -> Optional.of(eduOpenVPNServiceProvider.get())
-            org.eduvpn.common.Protocol.WireGuard.nativeValue -> Optional.of(wireGuardServiceProvider.get())
+            Protocol.OpenVPN.nativeValue -> Optional.of(eduOpenVPNServiceProvider.get())
+            Protocol.WireGuard.nativeValue, Protocol.WireGuardWithProxyGuard.nativeValue -> Optional.of(wireGuardServiceProvider.get())
             else -> Optional.empty()
         }
     }

--- a/app/src/main/java/nl/eduvpn/app/service/BackendService.kt
+++ b/app/src/main/java/nl/eduvpn/app/service/BackendService.kt
@@ -42,9 +42,9 @@ class BackendService(
     }
 
     enum class State(val nativeValue: Int) {
-        ASK_LOCATION(2),
-        OAUTH_STARTED(6),
-        ASK_PROFILE(9)
+        OAUTH_STARTED(3),
+        ASK_LOCATION(5),
+        ASK_PROFILE(6)
     }
 
     private val goBackend = GoBackend()
@@ -68,22 +68,13 @@ class BackendService(
         GoBackend.callbackFunction = object : Callback {
 
             // The library wants to get a token from our internal storage
-            override fun getToken(serverJson: String): String? {
-                // Find out the serverId
-                val parsedServer = serializerService.deserializeCurrentServer(serverJson)
-                parsedServer.getUniqueId()?.let { uniqueId ->
-                    return preferencesService.getToken(uniqueId)
-                }
-                return null
+            override fun getToken(serverId: String): String? {
+                return preferencesService.getToken(serverId)
             }
 
             // The library wants to save a token in our internal storage
-            override fun setToken(serverJson: String, token: String?) {
-                // Find out the serverId
-                val parsedServer = serializerService.deserializeCurrentServer(serverJson)
-                parsedServer.getUniqueId()?.let { uniqueId ->
-                    preferencesService.setToken(uniqueId, token)
-                }
+            override fun setToken(serverId: String, token: String?) {
+                preferencesService.setToken(serverId, token)
             }
 
             // Called when the native state machine changes
@@ -311,6 +302,22 @@ class BackendService(
             goBackend.cancelCookie(it)
             pendingOAuthCookie = null
         }
+    }
+
+    fun notifyConnecting() {
+        goBackend.notifyConnecting()
+    }
+
+    fun notifyConnected () {
+        goBackend.notifyConnected()
+    }
+
+    fun notifyDisconnecting() {
+        goBackend.notifyDisconnecting()
+    }
+
+    fun notifyDisconnected() {
+        goBackend.notifyDisconnected()
     }
 
     fun getLogFile() : File? {

--- a/app/src/main/java/nl/eduvpn/app/service/BackendService.kt
+++ b/app/src/main/java/nl/eduvpn/app/service/BackendService.kt
@@ -282,11 +282,11 @@ class BackendService(
         }
     }
 
-    fun selectCountry(cookie: Int?, countryCode: String) {
+    fun selectCountry(cookie: Int?, organizationId: String, countryCode: String) {
         val errorString = if (cookie != null) {
             goBackend.cookieReply(cookie, countryCode)
         } else {
-            goBackend.selectCountry(countryCode)
+            goBackend.selectCountry(organizationId, countryCode)
         }
         if (errorString != null) {
             throw CommonException(errorString)

--- a/app/src/main/java/nl/eduvpn/app/service/EduVPNOpenVPNService.java
+++ b/app/src/main/java/nl/eduvpn/app/service/EduVPNOpenVPNService.java
@@ -33,7 +33,6 @@ import androidx.lifecycle.FlowLiveDataConversions;
 import androidx.lifecycle.LiveData;
 
 import org.eduvpn.common.Protocol;
-import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -200,12 +199,12 @@ public class EduVPNOpenVPNService extends VPNService implements VpnStatus.StateL
      */
     public void connect(@NonNull Activity activity, @NonNull VpnProfile vpnProfile) {
         Log.i(TAG, "Initiating connection with profile:" + vpnProfile.getUUIDString());
-        boolean forceTcp = _preferencesService.getAppSettings().forceTcp();
-        Log.i(TAG, "Force TCP: " + forceTcp);
+        boolean preferTcp = _preferencesService.getAppSettings().preferTcp();
+        Log.i(TAG, "Prefet TCP: " + preferTcp);
         // If force TCP is enabled, disable the UDP connections
         for (Connection connection : vpnProfile.mConnections) {
             if (connection.mUseUdp) {
-                connection.mEnabled = !forceTcp;
+                connection.mEnabled = !preferTcp;
             }
         }
         // Make sure these changes are NOT saved, since we don't want the config changes to be permanent.

--- a/app/src/main/java/nl/eduvpn/app/service/PreferencesService.kt
+++ b/app/src/main/java/nl/eduvpn/app/service/PreferencesService.kt
@@ -146,13 +146,6 @@ class PreferencesService(
                     }
                 }
             }
-
-            val editor = insecurePreferences.edit()
-            editor.putInt(KEY_STORAGE_VERSION, STORAGE_VERSION)
-            editor.commit()
-            if (Constants.DEBUG) {
-                Log.d(TAG, "Migrated over to storage version v4.")
-            }
         }
         if (version < 5) {
             securePreferences.edit()
@@ -164,6 +157,12 @@ class PreferencesService(
             if (Constants.DEBUG) {
                 Log.d(TAG, "Migrated over to storage version v5.")
             }
+        }
+        val editor = insecurePreferences.edit()
+        editor.putInt(KEY_STORAGE_VERSION, STORAGE_VERSION)
+        editor.commit()
+        if (Constants.DEBUG) {
+            Log.d(TAG, "Migrated over to storage version v4.")
         }
     }
 
@@ -235,7 +234,7 @@ class PreferencesService(
      */
     fun getAppSettings(): Settings {
         val defaultSettings =
-            Settings(Settings.USE_CUSTOM_TABS_DEFAULT_VALUE, Settings.FORCE_TCP_DEFAULT_VALUE)
+            Settings(Settings.USE_CUSTOM_TABS_DEFAULT_VALUE, Settings.PREFER_TCP_DEFAULT_VALUE)
         val serializedSettings = getSharedPreferences().getString(KEY_APP_SETTINGS, null)
         return if (serializedSettings == null) {
             // Default settings.

--- a/app/src/main/java/nl/eduvpn/app/service/SerializerService.kt
+++ b/app/src/main/java/nl/eduvpn/app/service/SerializerService.kt
@@ -102,11 +102,11 @@ class SerializerService {
             if (jsonObject.has("use_custom_tabs")) {
                 useCustomTabs = jsonObject.getBoolean("use_custom_tabs")
             }
-            var forceTcp = Settings.FORCE_TCP_DEFAULT_VALUE
-            if (jsonObject.has("force_tcp")) {
-                forceTcp = jsonObject.getBoolean("force_tcp")
+            var preferTcp = Settings.PREFER_TCP_DEFAULT_VALUE
+            if (jsonObject.has("prefer_tcp")) {
+                preferTcp = jsonObject.getBoolean("prefer_tcp")
             }
-            Settings(useCustomTabs, forceTcp)
+            Settings(useCustomTabs, preferTcp)
         } catch (ex: JSONException) {
             throw UnknownFormatException(ex)
         }
@@ -124,7 +124,7 @@ class SerializerService {
         val result = JSONObject()
         return try {
             result.put("use_custom_tabs", settings.useCustomTabs())
-            result.put("force_tcp", settings.forceTcp())
+            result.put("prefer_tcp", settings.preferTcp())
             result
         } catch (ex: JSONException) {
             throw UnknownFormatException(ex)

--- a/app/src/main/java/nl/eduvpn/app/service/VPNConnectionService.kt
+++ b/app/src/main/java/nl/eduvpn/app/service/VPNConnectionService.kt
@@ -119,6 +119,10 @@ class VPNConnectionService(
         notificationManager.cancel(notificationID)
     }
 
+    fun protectSocket(fd: Int) {
+        wireGuardService.protectSocket(fd)
+    }
+
     companion object {
         fun vpnStatusToStringID(vpnStatus: VPNService.VPNStatus): Int {
             return when (vpnStatus) {

--- a/app/src/main/java/nl/eduvpn/app/service/VPNConnectionService.kt
+++ b/app/src/main/java/nl/eduvpn/app/service/VPNConnectionService.kt
@@ -8,6 +8,7 @@ import android.content.Intent
 import androidx.core.app.NotificationCompat
 import androidx.lifecycle.Observer
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import nl.eduvpn.app.Constants
 import nl.eduvpn.app.DisconnectVPNBroadcastReceiver
@@ -16,6 +17,7 @@ import nl.eduvpn.app.R
 import nl.eduvpn.app.entity.VPNConfig
 import nl.eduvpn.app.utils.FormattingUtils
 import nl.eduvpn.app.utils.pendingIntentImmutableFlag
+import org.eduvpn.common.Protocol
 
 class VPNConnectionService(
     private val preferencesService: PreferencesService,
@@ -44,6 +46,10 @@ class VPNConnectionService(
             }
             is VPNConfig.WireGuard -> {
                 scope.launch {
+                    if (preferencesService.getCurrentProtocol() == Protocol.WireGuardWithProxyGuard.nativeValue) {
+                        // Delay the start a bit to give it enough time to set up Proxyguard
+                        delay(2_000L)
+                    }
                     wireGuardService.connect(activity, vpnConfig.config)
                 }
                 wireGuardService

--- a/app/src/main/java/nl/eduvpn/app/service/WireGuardService.kt
+++ b/app/src/main/java/nl/eduvpn/app/service/WireGuardService.kt
@@ -3,6 +3,7 @@ package nl.eduvpn.app.service
 import android.app.Activity
 import android.app.Notification
 import android.content.Context
+import android.os.ParcelFileDescriptor
 import com.wireguard.android.backend.BackendException
 import com.wireguard.android.backend.GoBackend
 import com.wireguard.android.backend.Tunnel
@@ -24,8 +25,10 @@ import nl.eduvpn.app.livedata.TunnelData
 import nl.eduvpn.app.utils.Log
 import nl.eduvpn.app.utils.WireGuardTunnel
 import org.eduvpn.common.Protocol
+import java.lang.reflect.Method
 import java.net.Inet4Address
 import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 import kotlin.jvm.optionals.getOrNull
@@ -175,6 +178,21 @@ class WireGuardService(private val context: Context, timer: Flow<Unit>): VPNServ
             }
             pendingConfig = null
         }
+    }
+
+    fun protectSocket(fd: Int) {
+        // We need to use reflection here, because the required fields are not exposed sadly.
+        val field = GoBackend::class.java.getDeclaredField("vpnService")
+        // Make the field accessible since it's private
+        field.isAccessible = true
+        // Get the value of the vpnService field from the backend object
+        val vpnServiceFuture = field.get(backend)
+        // GhettoCompletableFuture class has a get() method to get the result
+        val vpnServiceInstance = vpnServiceFuture.javaClass.getMethod("get", Long::class.java, TimeUnit::class.java)
+            .invoke(vpnServiceFuture, 10L, TimeUnit.SECONDS)
+        val protectMethod: Method = vpnServiceInstance.javaClass.getMethod("protect", Int::class.java)
+        val result = protectMethod.invoke(vpnServiceInstance, fd) as Boolean
+        Log.i(TAG, "Protected socket with success: $result")
     }
 
     companion object {

--- a/app/src/main/java/nl/eduvpn/app/utils/ErrorDialog.kt
+++ b/app/src/main/java/nl/eduvpn/app/utils/ErrorDialog.kt
@@ -72,7 +72,7 @@ object ErrorDialog {
         } else if (thr is CommonException) {
             thr.translatedMessage()
         } else {
-            thr.localizedMessage ?: thr.toString()
+            thr.message ?: thr.toString()
         }
         return show(context, titleId, message)
     }

--- a/app/src/main/java/nl/eduvpn/app/viewmodel/BaseConnectionViewModel.kt
+++ b/app/src/main/java/nl/eduvpn/app/viewmodel/BaseConnectionViewModel.kt
@@ -99,7 +99,7 @@ abstract class BaseConnectionViewModel(
         viewModelScope.launch(Dispatchers.IO) {
             try {
                 preferencesService.setCurrentInstance(instance)
-                backendService.getConfig(instance, preferencesService.getAppSettings().forceTcp())
+                backendService.getConfig(instance, preferencesService.getAppSettings().preferTcp())
             } catch (ex: Exception) {
                 val errorString = if (ex is CommonException) {
                     ex.translatedMessage()
@@ -123,7 +123,7 @@ abstract class BaseConnectionViewModel(
     }
 
     public suspend fun selectProfileToConnectTo(profile: Profile) : Result<Unit> {
-        backendService.selectProfile(profile, preferencesService.getAppSettings().forceTcp())
+        backendService.selectProfile(profile, preferencesService.getAppSettings().preferTcp())
         return Result.success(Unit)
     }
 

--- a/app/src/main/java/nl/eduvpn/app/viewmodel/ConnectionStatusViewModel.kt
+++ b/app/src/main/java/nl/eduvpn/app/viewmodel/ConnectionStatusViewModel.kt
@@ -217,4 +217,19 @@ class ConnectionStatusViewModel @Inject constructor(
         }
         return true
     }
+
+    fun notifyVpnStatus(vpnStatus: VPNService.VPNStatus) {
+        when (vpnStatus) {
+            VPNService.VPNStatus.CONNECTED -> {
+                backendService.notifyConnected()
+            }
+            VPNService.VPNStatus.CONNECTING, VPNService.VPNStatus.PAUSED -> {
+                backendService.notifyConnecting()
+            }
+            VPNService.VPNStatus.DISCONNECTED, VPNService.VPNStatus.FAILED -> {
+                backendService.notifyDisconnecting()
+                backendService.notifyDisconnected()
+            }
+        }
+    }
 }

--- a/app/src/main/java/nl/eduvpn/app/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/nl/eduvpn/app/viewmodel/MainViewModel.kt
@@ -106,6 +106,18 @@ class MainViewModel @Inject constructor(
         preferTcp: Boolean
     ) {
         preferencesService.setCurrentProtocol(config.protocol)
+
+        if (config.protocol == Protocol.WireGuardWithProxyGuard.nativeValue && config.proxy != null) {
+            viewModelScope.launch(Dispatchers.IO) {
+                try {
+                    backendService.startProxyguard(config.proxy)
+                } catch (ex: CommonException) {
+                    // These are just warnings, so we log them, but don't display to the user
+                    Log.w( TAG, "Unable to start failover detection", ex)
+                }
+            }
+        }
+
         val parsedConfig = if (config.protocol == Protocol.OpenVPN.nativeValue) {
             eduVpnOpenVpnService.importConfig(
                 config.config,
@@ -144,18 +156,6 @@ class MainViewModel @Inject constructor(
                             }
                         }
                     }
-                } catch (ex: CommonException) {
-                    // These are just warnings, so we log them, but don't display to the user
-                    Log.w( TAG, "Unable to start failover detection", ex)
-                }
-            }
-        }
-        if (config.protocol == Protocol.WireGuardWithProxyGuard.nativeValue && config.proxy != null) {
-            viewModelScope.launch(Dispatchers.IO) {
-                try {
-                    // Waits a bit so that the network interface has been surely set up
-                    delay(1_000L)
-                    backendService.startProxyguard(config.proxy)
                 } catch (ex: CommonException) {
                     // These are just warnings, so we log them, but don't display to the user
                     Log.w( TAG, "Unable to start failover detection", ex)

--- a/app/src/main/java/nl/eduvpn/app/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/nl/eduvpn/app/viewmodel/MainViewModel.kt
@@ -115,6 +115,7 @@ class MainViewModel @Inject constructor(
                 VPNConfig.WireGuard(Config.parse(BufferedReader(StringReader(config.config))))
             } catch (ex: BadConfigException) {
                 // Notify the user that the config is not valid
+                Log.e(TAG, "Unable to parse WireGuard config", ex)
                 _mainParentAction.postValue(MainParentAction.ShowError(ex))
                 return
             }
@@ -122,7 +123,7 @@ class MainViewModel @Inject constructor(
             throw IllegalArgumentException("Unexpected protocol type: ${config.protocol}")
         }
         val service = vpnConnectionService.connectionToConfig(viewModelScope, activity, parsedConfig)
-        if (config.protocol == Protocol.WireGuard.nativeValue && !forceTCP) {
+        if (config.protocol == Protocol.WireGuard.nativeValue && !forceTCP && config.shouldFailover) {
             viewModelScope.launch(Dispatchers.IO) {
                 try {
                     // Waits a bit so that the network interface has been surely set up

--- a/app/src/main/java/nl/eduvpn/app/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/nl/eduvpn/app/viewmodel/MainViewModel.kt
@@ -176,9 +176,9 @@ class MainViewModel @Inject constructor(
         }
     }
 
-    fun onCountrySelected(cookie: Int?, countryCode: String) {
+    fun onCountrySelected(cookie: Int?, organizationId: String, countryCode: String) {
         viewModelScope.launch(Dispatchers.IO) {
-            backendService.selectCountry(cookie, countryCode)
+            backendService.selectCountry(cookie, organizationId, countryCode)
             historyService.load()
         }
     }

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -65,17 +65,17 @@
                     android:layout_below="@id/resetAppDataContainer" />
 
                 <androidx.appcompat.widget.AppCompatCheckBox
-                    android:id="@+id/forceTcpSwitch"
+                    android:id="@+id/preferTcpSwitch"
                     style="@style/SettingsLabelTitle"
                     android:layout_below="@id/resetDataSeparator"
                     android:paddingLeft="8dp"
-                    android:text="@string/settings_force_tcp_title" />
+                    android:text="@string/settings_prefer_tcp_title" />
 
 
                 <View
                     android:id="@+id/tcpSeparator"
                     style="@style/SettingsSeparator"
-                    android:layout_below="@id/forceTcpSwitch" />
+                    android:layout_below="@id/preferTcpSwitch" />
 
 
                 <androidx.appcompat.widget.AppCompatCheckBox

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -72,7 +72,6 @@
     <string name="callback_error">Error en el retorn: %s</string>
     <string name="rejected_permission">S\'ha refusat \'accés de l\'usuari per a l\'app.</string>
     <string name="settings_title">Preferències</string>
-    <string name="settings_force_tcp_title">Forçar TCP</string>
     <string name="settings_custom_tabs_opt_out_title">Emprar Pestanyes Personalitzades</string>
     <string name="settings_save">Desar</string>
     <string name="loading_available_profiles">Carregant perfils disponibles…</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -68,7 +68,6 @@
     <string name="callback_error">Callback-Fehler: %s</string>
     <string name="rejected_permission">Benutzer hat den Zugriff für die App abgelehnt.</string>
     <string name="settings_title">Einstellungen</string>
-    <string name="settings_force_tcp_title">TCP erzwingen</string>
     <string name="settings_custom_tabs_opt_out_title">Custom-Tabs verwenden</string>
     <string name="settings_save">Speichern</string>
     <string name="loading_available_profiles">Verfügbare Profile laden…</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -69,7 +69,6 @@
     <string name="callback_error">Error de devolución de llamada: %s</string>
     <string name="rejected_permission">El usuario rechaza el acceso a la aplicación.</string>
     <string name="settings_title">Configuraciones</string>
-    <string name="settings_force_tcp_title">Forzar TCP</string>
     <string name="settings_custom_tabs_opt_out_title">Usar Pestañas Personalizadas</string>
     <string name="settings_save">Guardar</string>
     <string name="loading_available_profiles">Cargando perfiles disponibles…</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -72,7 +72,7 @@
     <string name="callback_error">Callback error: %s</string>
     <string name="rejected_permission">User rejected access for the app.</string>
     <string name="settings_title">Settings</string>
-    <string name="settings_force_tcp_title">Force TCP</string>
+    <string name="settings_prefer_tcp_title">Prefer TCP</string>
     <string name="settings_custom_tabs_opt_out_title">Use Custom Tabs</string>
     <string name="settings_save">Save</string>
     <string name="loading_available_profiles">Loading available profiles…</string>

--- a/common/src/main/cpp/jni.cpp
+++ b/common/src/main/cpp/jni.cpp
@@ -186,6 +186,7 @@ extern "C" JNIEXPORT jstring JNICALL
 Java_org_eduvpn_common_GoBackend_addServer(JNIEnv *env, jobject /* this */, jint serverType, jstring id) {
     uintptr_t cookie = CookieNew();
     const char *id_str = env->GetStringUTFChars(id, nullptr);
+    SetState(1); // Change first to main state to make sure we are not in a previous state.
     char *error = AddServer(cookie, (int)serverType, (char *)id_str, 0);
     CookieDelete(cookie);
     // Do not delete the cookie, because it might be reused later in the flow
@@ -286,4 +287,28 @@ extern "C"
 JNIEXPORT void JNICALL
 Java_org_eduvpn_common_GoBackend_updateRxBytesRead(JNIEnv *env, jobject /* this */, jlong rxBytesRead) {
     globalRxBytesRead = rxBytesRead;
+}
+
+extern "C"
+JNIEXPORT void JNICALL
+Java_org_eduvpn_common_GoBackend_notifyConnecting(JNIEnv *env, jobject /* this */) {
+    SetState(8);
+}
+
+extern "C"
+JNIEXPORT void JNICALL
+Java_org_eduvpn_common_GoBackend_notifyConnected(JNIEnv *env, jobject /* this */) {
+    SetState(9);
+}
+
+extern "C"
+JNIEXPORT void JNICALL
+Java_org_eduvpn_common_GoBackend_notifyDisconnecting(JNIEnv *env, jobject /* this */) {
+    SetState(10);
+}
+
+extern "C"
+JNIEXPORT void JNICALL
+Java_org_eduvpn_common_GoBackend_notifyDisconnected(JNIEnv *env, jobject /* this */) {
+    SetState(11);
 }

--- a/common/src/main/cpp/jni.cpp
+++ b/common/src/main/cpp/jni.cpp
@@ -330,22 +330,6 @@ Java_org_eduvpn_common_GoBackend_notifyDisconnected(JNIEnv *env, jobject /* this
     SetState(11);
 }
 
-// StartProxyguard starts the 'proxyguard' procedure in eduvpn-common.
-// This proxies WireGuard UDP connections over HTTP: https://codeberg.org/eduvpn/proxyguard.
-// These input variables can be gotten from the configuration that is retrieved using the `proxy` JSON key
-//
-//   - `c` is the cookie
-//   - `listen` is the ip:port of the local udp connection, this is what is set to the WireGuard endpoint
-//   - `tcpsp` is the TCP source port
-//   - `peer` is the ip:port of the remote server
-//   - `proxyFD` is a callback with the file descriptor as only argument. It can be used to set certain
-//     socket option, e.g. to exclude the proxy connection from going over the VPN
-//
-// If the proxy cannot be started it returns an error
-//
-//export StartProxyguard
-
-
 extern "C"
 JNIEXPORT jstring JNICALL
 Java_org_eduvpn_common_GoBackend_startProxyGuard(JNIEnv *env, jobject /* this */, jint sourcePort, jstring listen, jstring peer) {

--- a/common/src/main/cpp/jni.cpp
+++ b/common/src/main/cpp/jni.cpp
@@ -85,9 +85,7 @@ int createStateCallback(int oldstate, int newstate, void *data) {
     return callGlobalCallback(newstate, data);
 }
 
-
-
-void getToken(const char* server, char* out, size_t len) {
+void getToken(const char* server, int server_type, char* out, size_t len) {
     if (!globalVM) {
         return;
     }
@@ -108,7 +106,7 @@ void getToken(const char* server, char* out, size_t len) {
         globalVM->DetachCurrentThread();
     }
 }
-void setToken(const char* server, const char* tokens) {
+void setToken(const char* server, int server_type, const char* tokens) {
     if (!globalVM) {
         return;
     }
@@ -258,11 +256,10 @@ Java_org_eduvpn_common_GoBackend_deregister(JNIEnv *env, jobject /* this */) {
     return NativeStringToJString(env, result);
 }
 extern "C" JNIEXPORT jstring JNICALL
-Java_org_eduvpn_common_GoBackend_selectCountry(JNIEnv *env, jobject /* this */, jstring countryCode) {
-    uintptr_t cookie = CookieNew();
+Java_org_eduvpn_common_GoBackend_selectCountry(JNIEnv *env, jobject /* this */, jstring organizationId, jstring countryCode) {
     const char *countryCode_str = env->GetStringUTFChars(countryCode, nullptr);
-    char *result = SetSecureLocation(cookie, (char *)countryCode_str);
-    CookieDelete(cookie);
+    const char *organizationId_str = env->GetStringUTFChars(organizationId, nullptr);
+    char *result = SetSecureLocation((char *)organizationId_str, (char *)countryCode_str);
     return NativeStringToJString(env, result);
 }
 

--- a/common/src/main/java/org/eduvpn/common/GoBackend.java
+++ b/common/src/main/java/org/eduvpn/common/GoBackend.java
@@ -11,6 +11,8 @@ public class GoBackend {
         boolean onNewState(int newState, @Nullable String data);
         @Nullable String getToken(@NonNull String serverId);
         void setToken(@NonNull String serverId, @Nullable String token);
+
+        void onProxyFileDescriptor(int fileDescriptor);
     }
 
     public static Callback callbackFunction = null;
@@ -46,4 +48,5 @@ public class GoBackend {
     public native void notifyConnected();
     public native void notifyDisconnecting();
     public native void notifyDisconnected();
+    public native @Nullable String startProxyGuard(int sourcePort, @NotNull String listen, @NotNull String peer);
 }

--- a/common/src/main/java/org/eduvpn/common/GoBackend.java
+++ b/common/src/main/java/org/eduvpn/common/GoBackend.java
@@ -42,4 +42,8 @@ public class GoBackend {
     public native DataErrorTuple getCertExpiryTimes();
     public native void updateRxBytesRead(long rxBytesRead);
     public native FailoverResult startFailOver(@NotNull String gatewayIp, int mtu);
+    public native void notifyConnecting();
+    public native void notifyConnected();
+    public native void notifyDisconnecting();
+    public native void notifyDisconnected();
 }

--- a/common/src/main/java/org/eduvpn/common/GoBackend.java
+++ b/common/src/main/java/org/eduvpn/common/GoBackend.java
@@ -34,7 +34,7 @@ public class GoBackend {
     public native @Nullable String removeServer(int serverType, @NonNull String id);
     public native @Nullable String cookieReply(int cookie, @NotNull String data);
     public native @Nullable String selectProfile(int cookie, @NotNull String profileId);
-    public native @Nullable String selectCountry(@NotNull String countryCode);
+    public native @Nullable String selectCountry(@NotNull String organizationId, @NotNull String countryCode);
     public native @Nullable String switchProfile(@NotNull String profileId);
     public native DataErrorTuple getCurrentServer();
     public native @Nullable String cancelCookie(int cookie);

--- a/common/src/main/java/org/eduvpn/common/Protocol.java
+++ b/common/src/main/java/org/eduvpn/common/Protocol.java
@@ -3,7 +3,8 @@ package org.eduvpn.common;
 public enum Protocol {
     Unknown(0),
     OpenVPN(1),
-    WireGuard(2);
+    WireGuard(2),
+    WireGuardWithProxyGuard(3);
 
     public final Integer nativeValue;
     Protocol(Integer nativeValue) {


### PR DESCRIPTION
* Updates the common library, changes some code that we now integrate correctly with the changes made in the library
* Adds support for Proxyguard. We need to use reflection here, because the Wireguard Go backend does not expose its VPN service, and we need that to protect our socket File Descriptor
* Renamed "Force TCP" to "Prefer TCP", to be inline with the API rename
* The app now notifies the common library about the VPN state changes
* Added crash handling for some edge cases, such as invalid WireGuard configs
* Improved the ProGuard config so that it does not obfuscate file names and line numbers